### PR TITLE
Fix mutability leak in split_at() unsafe code.

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -80,7 +80,7 @@ impl BitMatrix {
     pub fn split_at(&self, row: usize)
                     -> (BitSubMatrix,
                         &BitVecSlice,
-                        BitSubMatrixMut) {
+                        BitSubMatrix) {
         unsafe {
             (mem::transmute(self.sub_matrix(0 .. row)),
              mem::transmute(&self[row]),


### PR DESCRIPTION
Probably a copy paste error from split_at_mut().